### PR TITLE
feat: add Docker Compose deployment support

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,64 @@
+# Git
+.git/
+.gitignore
+.gitattributes
+
+# Dependencies (will be installed fresh in container)
+node_modules/
+**/node_modules/
+
+# Next.js build output (will be built in container)
+.next/
+**/.next/
+out/
+
+# Logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Environment files (except example)
+.env
+.env.local
+.env.development
+.env.development.local
+.env.test
+.env.test.local
+.env.production
+.env.production.local
+!.env.example
+
+# Test and coverage
+coverage/
+playwright-report/
+test-results/
+*.spec.ts
+*.test.ts
+
+# Project-specific exclusions
+.beads/
+scripts/
+tests/
+acfs/
+docs/
+
+# Documentation (except main README)
+*.md
+!README.md
+
+# IDE and editor
+.vscode/
+.idea/
+*.swp
+*.swo
+*~
+
+# OS files
+.DS_Store
+Thumbs.db
+
+# Misc
+*.tgz
+.vercel
+.turbo

--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,32 @@
+# ACFS Web Environment Variables
+# Copy this file to .env and fill in your values
+
+# =============================================================================
+# Google Analytics 4 (optional)
+# =============================================================================
+# Your GA4 measurement ID (format: G-XXXXXXXXXX)
+NEXT_PUBLIC_GA_MEASUREMENT_ID=
+
+# Google Tag Manager container ID (format: GTM-XXXXXXX)
+NEXT_PUBLIC_GTM_ID=
+
+# GA4 API secret for server-side events (Measurement Protocol)
+GA_API_SECRET=
+
+# =============================================================================
+# Microsoft Clarity (optional)
+# =============================================================================
+# Clarity project ID for session recordings and heatmaps
+NEXT_PUBLIC_CLARITY_PROJECT_ID=
+
+# =============================================================================
+# Vercel Analytics (optional)
+# =============================================================================
+# Note: These only work when deployed on Vercel. For self-hosted deployments,
+# leave these empty or set to 'false'.
+
+# Enable Vercel Web Analytics (true/false)
+NEXT_PUBLIC_ENABLE_VERCEL_ANALYTICS=false
+
+# Enable Vercel Speed Insights (true/false)
+NEXT_PUBLIC_ENABLE_SPEED_INSIGHTS=false

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,46 @@
+# syntax=docker/dockerfile:1
+
+FROM oven/bun:1-alpine AS base
+WORKDIR /app
+
+FROM base AS deps
+
+COPY package.json bun.lock ./
+COPY apps/web/package.json apps/web/bun.lock ./apps/web/
+COPY packages/manifest/package.json ./packages/manifest/
+
+RUN bun install --frozen-lockfile
+
+FROM base AS builder
+
+ENV NEXT_TELEMETRY_DISABLED=1
+
+COPY --from=deps /app/node_modules ./node_modules
+
+COPY . .
+
+WORKDIR /app/apps/web
+RUN bun install --frozen-lockfile && bun run build
+
+FROM node:22-alpine AS runner
+WORKDIR /app
+
+ENV NODE_ENV=production
+ENV NEXT_TELEMETRY_DISABLED=1
+
+RUN addgroup --system --gid 1001 nodejs && \
+    adduser --system --uid 1001 nextjs
+
+COPY --from=builder --chown=nextjs:nodejs /app/apps/web/.next/standalone ./
+
+COPY --from=builder --chown=nextjs:nodejs /app/apps/web/.next/static ./apps/web/.next/static
+COPY --from=builder --chown=nextjs:nodejs /app/apps/web/public ./apps/web/public
+
+USER nextjs
+
+EXPOSE 3000
+
+ENV PORT=3000
+ENV HOSTNAME=0.0.0.0
+
+CMD ["node", "apps/web/server.js"]

--- a/README.md
+++ b/README.md
@@ -1337,6 +1337,54 @@ agentic_coding_flywheel_setup/
 
 ---
 
+## Docker Deployment
+
+ACFS can be deployed using Docker Compose for self-hosted environments.
+
+### Quick Start
+
+```bash
+# Clone and build
+git clone https://github.com/Dicklesworthstone/agentic_coding_flywheel_setup.git
+cd agentic_coding_flywheel_setup
+
+# Build and run
+docker compose up -d
+
+# View logs
+docker compose logs -f
+
+# Stop
+docker compose down
+```
+
+### Configuration
+
+Copy `.env.example` to `.env` to configure optional analytics:
+
+```bash
+cp .env.example .env
+# Edit .env with your values
+```
+
+Available environment variables:
+| Variable | Description |
+|----------|-------------|
+| `NEXT_PUBLIC_GA_MEASUREMENT_ID` | Google Analytics 4 measurement ID |
+| `NEXT_PUBLIC_GTM_ID` | Google Tag Manager ID |
+| `GA_API_SECRET` | GA4 Measurement Protocol secret |
+| `NEXT_PUBLIC_CLARITY_PROJECT_ID` | Microsoft Clarity project ID |
+
+### Production Considerations
+
+For production deployments:
+- Use a reverse proxy (nginx, Traefik, Caddy) for SSL termination
+- Set resource limits in docker-compose.yml
+- Configure proper logging aggregation
+- Use Docker secrets for sensitive environment variables
+
+---
+
 ## Development
 
 ### Website Development

--- a/apps/web/next.config.ts
+++ b/apps/web/next.config.ts
@@ -6,6 +6,10 @@ const configDir = dirname(fileURLToPath(import.meta.url));
 const workspaceRoot = resolve(configDir, "../..");
 
 const nextConfig: NextConfig = {
+  // Enable standalone output for Docker deployment
+  output: "standalone",
+  // Required for monorepo: tells Next.js to trace dependencies from workspace root
+  outputFileTracingRoot: workspaceRoot,
   turbopack: {
     // Bun workspaces install deps at the workspace root; Turbopack needs this
     // to resolve `next` and other packages when multiple lockfiles exist.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,24 @@
+services:
+  web:
+    build: .
+    ports:
+      - "3000:3000"
+    environment:
+      - NODE_ENV=production
+      - PORT=3000
+      - HOSTNAME=0.0.0.0
+      # Google Analytics (optional)
+      - NEXT_PUBLIC_GA_MEASUREMENT_ID=${NEXT_PUBLIC_GA_MEASUREMENT_ID:-}
+      - NEXT_PUBLIC_GTM_ID=${NEXT_PUBLIC_GTM_ID:-}
+      - GA_API_SECRET=${GA_API_SECRET:-}
+      # Microsoft Clarity (optional)
+      - NEXT_PUBLIC_CLARITY_PROJECT_ID=${NEXT_PUBLIC_CLARITY_PROJECT_ID:-}
+      # Vercel Analytics (optional, usually disabled for self-hosted)
+      - NEXT_PUBLIC_ENABLE_VERCEL_ANALYTICS=${NEXT_PUBLIC_ENABLE_VERCEL_ANALYTICS:-}
+      - NEXT_PUBLIC_ENABLE_SPEED_INSIGHTS=${NEXT_PUBLIC_ENABLE_SPEED_INSIGHTS:-}
+    restart: unless-stopped
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://localhost:3000/"]
+      interval: 30s
+      timeout: 10s
+      retries: 3


### PR DESCRIPTION
## Summary
- Add Docker Compose configuration for self-hosted deployment of the ACFS web wizard
- Enable standalone Next.js output for optimized Docker builds

## Changes
- `Dockerfile` - Multi-stage build using Bun for deps/build, Node for runtime
- `docker-compose.yml` - Service orchestration with health checks and env var support
- `.dockerignore` - Exclude unnecessary files from build context
- `.env.example` - Document optional analytics environment variables
- `apps/web/next.config.ts` - Add `output: 'standalone'` for Docker compatibility
- `README.md` - Add Docker deployment documentation section

## Usage
```bash
docker compose up -d
```