### PR TITLE
Fix uv checksum: replace FETCH_FAILED with actual SHA256

### DIFF
--- a/checksums.yaml
+++ b/checksums.yaml
@@ -28,7 +28,7 @@ installers:
 
   uv:
     url: "https://astral.sh/uv/install.sh"
-    sha256: "FETCH_FAILED"
+    sha256: "38a2a3fb4d169fbc5b3533d1690feb9b1d909a74514a18169e1a2371fd4f3104"
 
   ntm:
     url: "https://raw.githubusercontent.com/Dicklesworthstone/ntm/main/install.sh"


### PR DESCRIPTION
## Summary

The `checksums.yaml` file has `FETCH_FAILED` for the uv installer's SHA256, which causes installation to fail during checksum verification.

This PR replaces it with the actual SHA256 hash of the current uv install script from https://astral.sh/uv/install.sh

## Test plan

- Run the installer and verify uv installs successfully without checksum errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)