### PR TITLE
Remove redundant ENABLE_BACKGROUND_TASKS=1 from cc alias

### DIFF
--- a/PLAN_TO_CREATE_ACFS.md
+++ b/PLAN_TO_CREATE_ACFS.md
@@ -180,7 +180,7 @@ ACFS consists of **three products in one repo**:
 
 ```bash
 # Coding agents (dangerously enabled for vibe mode)
-alias cc='NODE_OPTIONS="--max-old-space-size=32768" ENABLE_BACKGROUND_TASKS=1 claude --dangerously-skip-permissions'
+alias cc='NODE_OPTIONS="--max-old-space-size=32768" claude --dangerously-skip-permissions'
 alias cod='codex --dangerously-bypass-approvals-and-sandbox -m gpt-5.2-codex -c model_reasoning_effort="xhigh" -c model_reasoning_summary_format=experimental --enable web_search_request'
 alias gmi='gemini --yolo --model gemini-3-pro-preview'
 

--- a/README.md
+++ b/README.md
@@ -1189,8 +1189,8 @@ Benefits for agentic workflows:
 
 **Vibe Mode Aliases:**
 ```bash
-# Claude Code with max memory and background tasks
-alias cc='NODE_OPTIONS="--max-old-space-size=32768" ENABLE_BACKGROUND_TASKS=1 claude --dangerously-skip-permissions'
+# Claude Code with max memory
+alias cc='NODE_OPTIONS="--max-old-space-size=32768" claude --dangerously-skip-permissions'
 
 # Codex with bypass and dangerous filesystem access
 alias cod='codex --dangerously-bypass-approvals-and-sandbox'

--- a/acfs/onboard/lessons/04_agents_login.md
+++ b/acfs/onboard/lessons/04_agents_login.md
@@ -23,11 +23,9 @@ The aliases are configured for **maximum power** (vibe mode):
 ### `cc` (Claude Code)
 ```bash
 NODE_OPTIONS="--max-old-space-size=32768" \
-  ENABLE_BACKGROUND_TASKS=1 \
   claude --dangerously-skip-permissions
 ```
 - Extra memory for large projects
-- Background task support
 - No permission prompts
 
 ### `cod` (Codex CLI)

--- a/acfs/zsh/acfs.zshrc
+++ b/acfs/zsh/acfs.zshrc
@@ -372,7 +372,7 @@ acfs() {
 }
 
 # --- Agent aliases (dangerously enabled by design) ---
-alias cc='NODE_OPTIONS="--max-old-space-size=32768" ENABLE_BACKGROUND_TASKS=1 ~/.local/bin/claude --dangerously-skip-permissions'
+alias cc='NODE_OPTIONS="--max-old-space-size=32768" ~/.local/bin/claude --dangerously-skip-permissions'
 alias cod='codex --dangerously-bypass-approvals-and-sandbox'
 alias gmi='gemini --yolo'
 

--- a/apps/web/components/lessons/agents-login-lesson.tsx
+++ b/apps/web/components/lessons/agents-login-lesson.tsx
@@ -87,11 +87,9 @@ export function AgentsLoginLesson() {
             alias="cc"
             name="Claude Code"
             code={`NODE_OPTIONS="--max-old-space-size=32768" \\
-  ENABLE_BACKGROUND_TASKS=1 \\
   claude --dangerously-skip-permissions`}
             features={[
               "Extra memory for large projects",
-              "Background task support",
               "No permission prompts",
             ]}
             gradient="from-orange-500/20 to-amber-500/20"


### PR DESCRIPTION
## Summary

Remove the `ENABLE_BACKGROUND_TASKS=1` environment variable from the `cc` alias since it's redundant and not officially documented.

## Why This Change

**Background tasks are enabled by default in Claude Code.** The only documented way to control this feature is `CLAUDE_CODE_DISABLE_BACKGROUND_TASKS=1` to disable it.

`ENABLE_BACKGROUND_TASKS` is not a documented environment variable:
- Not in [official Claude Code settings documentation](https://code.claude.com/docs/en/settings)
- Not in the [CHANGELOG.md](https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md)
- Only appears in bug reports where users try to set it to `false` to disable background tasks (which [doesn't work per issue #10210](https://github.com/anthropics/claude-code/issues/10210))

Since background tasks are already enabled by default, setting `ENABLE_BACKGROUND_TASKS=1` has no effect and adds confusion.

## Changes

- `acfs/zsh/acfs.zshrc` - Remove from cc alias
- `acfs/onboard/lessons/04_agents_login.md` - Remove from documentation
- `apps/web/components/lessons/agents-login-lesson.tsx` - Remove from React component
- `README.md` - Remove from documentation
- `PLAN_TO_CREATE_ACFS.md` - Remove from planning doc

## Test plan

- [x] Verify `cc` alias still works without the env var
- [x] Confirm background tasks still function (they're on by default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)