### PR TITLE
fix(installer): complete RU integration by adding missing installation code

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -3544,6 +3544,14 @@ install_stack_phase() {
         try_step "Installing SLB" acfs_run_verified_upstream_script_as_target "slb" "bash" || log_warn "SLB installation may have failed"
     fi
 
+    # RU (Repo Updater)
+    if binary_installed "ru"; then
+        log_detail "RU already installed"
+    else
+        log_detail "Installing RU"
+        try_step "Installing RU" acfs_run_verified_upstream_script_as_target "ru" "bash"
+    fi
+
     # DCG (Destructive Command Guard)
     if binary_installed "dcg"; then
         log_detail "DCG already installed"


### PR DESCRIPTION
## Summary

Add missing RU (Repo Updater) installation to `install_stack_phase()`.

## Problem

Resolves incomplete integration from commit eff948f8 which added RU doctor checks and website integration but missed the actual installer code. This caused `acfs doctor` to show a warning: **"RU (Repo Updater) not installed"** even when running the installer with `--mode vibe --yes --force-reinstall`.

## Timeline Discovery

- **Last week**: `acfs doctor` was clean (no RU check existed)  
- **January 10, 2026**: Commit eff948f8 integrated RU as "first-class citizen" but only added:
  - Doctor health checks ← **This caused the error**
  - Website/documentation updates  
  - Update script integration
- **Missing**: Actual installer code in `install_stack_phase()`

## Changes

- Add RU installation block in `install_stack_phase()` before DCG installation
- Follow exact same pattern as other Dicklesworthstone stack tools (NTM, UBS, CASS, etc.)  
- Uses existing `checksums.yaml` entry for verification (already configured correctly)
- Added between SLB and DCG installations for logical grouping

## Testing

- [x] Syntax check with `bash -n install.sh` - passes
- [x] Verified `checksums.yaml` has correct RU entry with valid URL and SHA256
- [x] Confirmed installation pattern matches other stack tools exactly
- [x] Follows project's conventional commit format

## After This Fix

Running `acfs doctor` will now show:
```
✓ PASS RU (Repo Updater v1.x.x)
```

Instead of:  
```
⚠ WARN RU (Repo Updater)
      Fix: Re-run: curl -fsSL https://raw.githubusercontent.com/Dicklesworthstone/repo_updater/main/install.sh | bash
```