### PR TITLE
fix(doctor): correct invalid PostgreSQL parameterized query syntax

### DIFF
--- a/scripts/lib/doctor.sh
+++ b/scripts/lib/doctor.sh
@@ -1319,20 +1319,20 @@ check_postgres_role() {
 
     # Try to check if target user role exists
     # pg_roles view is readable by any authenticated user - no superuser required
-    # SECURITY: Use psql -v to pass variable and :'var' syntax for safe interpolation
+    # SECURITY: Safe to use bash variable substitution since target_user is validated with regex above
     local role_check
     local connect_success=false
-    local sql_query="SELECT 1 FROM pg_roles WHERE rolname=:'target_user'"
+    local sql_query="SELECT 1 FROM pg_roles WHERE rolname='$target_user'"
 
     # Try connecting as current user first (mirrors check_postgres_connection behavior)
     # This works when pg_hba.conf allows peer auth for local users
-    if role_check=$(timeout 5 psql -w -tAc "$sql_query" -v target_user="$target_user" 2>/dev/null); then
+    if role_check=$(timeout 5 psql -w -tAc "$sql_query" 2>/dev/null); then
         connect_success=true
     # Try localhost with postgres user as fallback
-    elif role_check=$(timeout 5 psql -w -h localhost -U postgres -tAc "$sql_query" -v target_user="$target_user" 2>/dev/null); then
+    elif role_check=$(timeout 5 psql -w -h localhost -U postgres -tAc "$sql_query" 2>/dev/null); then
         connect_success=true
     # Try unix socket with postgres user as last resort
-    elif role_check=$(timeout 5 psql -w -h /var/run/postgresql -U postgres -tAc "$sql_query" -v target_user="$target_user" 2>/dev/null); then
+    elif role_check=$(timeout 5 psql -w -h /var/run/postgresql -U postgres -tAc "$sql_query" 2>/dev/null); then
         connect_success=true
     fi
 


### PR DESCRIPTION
## Summary

Fix PostgreSQL role check that was failing due to invalid psql syntax introduced in commit 5cad1a8d, causing false negatives for existing roles.

## Problem

The `check_postgres_role` function uses invalid PostgreSQL syntax that causes a syntax error:

```sql
SELECT 1 FROM pg_roles WHERE rolname=:'target_user'
```

**Error produced:**
```
ERROR: syntax error at or near ":"
LINE 1: SELECT 1 FROM pg_roles WHERE rolname=:'target_user'
                                             ^
```

## Root Cause Analysis

**Timeline of the PostgreSQL check:**

1. **Original issue**: PR #32 (Jan 6) identified role check only tried postgres superuser, failed with password auth
2. **Correct fix applied**: Maintainer implemented "try current user first" logic (worked perfectly)  
3. **Bug introduced**: Commit 5cad1a8d (Jan 11) attempted SQL injection prevention but used invalid syntax

**The problematic commit:**
```bash
# Commit 5cad1a8d: "fix: security and accessibility improvements"
# Attempted to use psql parameterized queries but syntax is wrong
psql -w -tAc "SELECT 1 FROM pg_roles WHERE rolname=:'target_user'" -v target_user="ubuntu"
```

**The `:'variable'` syntax doesn't exist in PostgreSQL/psql.** This isn't valid parameterized query syntax.

## Current Broken Behavior

1. ✅ Connection succeeds (as current user)
2. ❌ SQL query fails with syntax error  
3. ❌ Falls back to postgres user attempts (fail due to auth requirements)
4. 🚨 **Result**: `⚠ WARN PostgreSQL ubuntu role` despite role existing and being accessible

## Solution

Replace invalid syntax with safe bash variable substitution:

```sql
-- Before (broken):
SELECT 1 FROM pg_roles WHERE rolname=:'target_user'

-- After (working):  
SELECT 1 FROM pg_roles WHERE rolname='$target_user'
```

**Security**: This is safe because `target_user` is validated with regex `^[a-zA-Z_][a-zA-Z0-9_]*$` before use, preventing SQL injection.

## Testing

**Before fix:**
```
⚠ WARN PostgreSQL ubuntu role
      Fix: sudo -u postgres createuser -s ubuntu
```

**After fix:**
```
✓ PASS PostgreSQL ubuntu role
```

**Verification:**
- Ubuntu role exists: `psql -tAc "SELECT 1 FROM pg_roles WHERE rolname='ubuntu'"` → `1` ✅
- Current user can connect: `psql -w -c 'SELECT 1'` → `1` ✅  
- Role check now works: No false negatives ✅

## Relationship to Previous Work

This completes the PostgreSQL role detection improvements that were:
- **Originally identified** in PR #32 (user reported connection approach issue)
- **Correctly implemented** initially (try current user first)  
- **Accidentally broken** by well-intentioned security improvement using invalid syntax

The core logic from PR #32 (try current user first, fallback to postgres user) remains intact and correct. This fix only corrects the SQL syntax issue.