### PR TITLE
fix(gum_ui): add missing ACFS_TEAL color variable

### DIFF
--- a/scripts/lib/gum_ui.sh
+++ b/scripts/lib/gum_ui.sh
@@ -18,6 +18,7 @@ ACFS_WARNING="#f9e2af"    # Yellow
 ACFS_ERROR="#f38ba8"      # Red
 ACFS_MUTED="#6c7086"      # Gray
 ACFS_ACCENT="#cba6f7"     # Purple
+ACFS_TEAL="#94e2d5"       # Teal
 ACFS_PINK="#f5c2e7"       # Pink
 
 # ASCII Art Banner for ACFS


### PR DESCRIPTION
## Summary

Fix `acfs services-setup` failing with "unbound variable" error by adding missing `ACFS_TEAL` color variable to gum_ui.sh.

## Problem

Running `acfs services-setup` fails immediately with:

```bash
/home/ubuntu/.acfs/scripts/services-setup.sh: line 1156: ACFS_TEAL: unbound variable
```

## Root Cause

**Missing color variable definition:**
- `services-setup.sh` line 1156 uses `$ACFS_TEAL` for styling user info
- `gum_ui.sh` defines all ACFS color variables except `ACFS_TEAL` 
- Script runs with `set -u` (treats unset variables as errors)

**Current gum_ui.sh color scheme:** ✅ Defined
```bash
ACFS_PRIMARY="#89b4fa"    # Blue
ACFS_SUCCESS="#a6e3a1"    # Green  
ACFS_WARNING="#f9e2af"    # Yellow
ACFS_ERROR="#f38ba8"      # Red
ACFS_MUTED="#6c7086"      # Gray
ACFS_ACCENT="#cba6f7"     # Purple
ACFS_PINK="#f5c2e7"       # Pink
# ACFS_TEAL missing! ❌
```

**Used but undefined:**
```bash
# Line 1156 in services-setup.sh:
gum style --foreground "$ACFS_TEAL" "  User: $TARGET_USER"
```

## Solution

Add missing `ACFS_TEAL` color variable to the ACFS color scheme:

```bash
ACFS_TEAL="#94e2d5"       # Teal
```

**Color choice rationale:**
- Matches the value used in `doctor.sh` (`ACFS_TEAL="${ACFS_TEAL:-#94e2d5}"`)
- Consistent with Catppuccin Mocha inspired color scheme
- Provides good contrast for user information display

## Testing

**Before fix:**
```bash
$ acfs services-setup
/home/ubuntu/.acfs/scripts/services-setup.sh: line 1156: ACFS_TEAL: unbound variable
```

**After fix:**
```bash
$ acfs services-setup
╔════════════════════════════════════════════╗
║                                            ║
║   ⚙️  ACFS Services Setup                  ║
║   Configure AI agents and cloud services   ║
║                                            ║
╚════════════════════════════════════════════╝

  User: ubuntu
  
┌──────────────────┐
│  Service Status  │
└──────────────────┘
```

✅ **services-setup now runs successfully** without unbound variable errors.

## Impact

- **Fixes broken command**: `acfs services-setup` now works as intended
- **No functional changes**: Only adds missing color definition
- **Maintains consistency**: All ACFS color variables now properly defined
- **Backward compatible**: Existing color usage unaffected

This is a simple but critical fix for a command that users need to configure AI agents and cloud services after installation.