### PR TITLE
Fix: Locale-dependent regex bug in checksum loader causing update failures

### DIFF
--- a/scripts/lib/security.sh
+++ b/scripts/lib/security.sh
@@ -557,7 +557,7 @@ load_checksums() {
         fi
 
         # Match tool name (a mapping key line like "  bun:")
-        if [[ "$line" =~ ^[[:space:]]*([A-Za-z0-9_-]+):[[:space:]]*$ ]]; then
+        if [[ "$line" =~ ^[[:space:]]*([[:alnum:]_-]+):[[:space:]]*$ ]]; then
             if [[ -z "$tool_indent" ]]; then
                 tool_indent="$indent_len"
             fi


### PR DESCRIPTION
## Problem

The `load_checksums()` function in `scripts/lib/security.sh` has a locale-dependent regex bug that causes checksum loading failures for specific tools.

### Symptoms
- 4 tools fail to load checksums: `atuin`, `zoxide`, `giil`, `mcp_agent_mail`
- Update commands fail with "Missing checksum entry" errors
- Checksum misalignment (wrong checksums assigned to tools)

### Root Cause
The regex pattern `[A-Za-z0-9_-]` on line 560 doesn't work correctly in UTF-8 locales (e.g., `C.UTF-8`). In some UTF-8 locales, the `[A-Za-z]` character class has unexpected behavior due to locale-specific collation rules.

## Solution
Replace `[A-Za-z0-9_-]` with `[[:alnum:]_-]` - the POSIX `[:alnum:]` character class works correctly across all locales.

## Testing
Tested on Ubuntu 25.10 with `C.UTF-8` locale:

**Before fix:**
- 16/20 checksums loaded
- atuin, zoxide, giil, mcp_agent_mail: Failed with "Missing checksum entry"
- CASS: Wrong checksum (got mcp_agent_mail's checksum due to misalignment)

**After fix:**
- ✅ 20/20 checksums loaded correctly
- ✅ All 4 previously failing tools now install successfully
- ✅ No checksum misalignment
- ✅ `acfs update --stack` completes with 0 failures

## Impact
This is a critical bug that affects all ACFS installations on systems with UTF-8 locales (which is the default on most modern Linux distributions).

## Related
This bug was discovered while troubleshooting update failures on a production VPS running Ubuntu 25.10.