### PR TITLE
fix: correct bd config set syntax (use = instead of space)

### DIFF
--- a/.beads/config.yaml
+++ b/.beads/config.yaml
@@ -41,7 +41,7 @@ auto-start-daemon: false
 # IMPORTANT: Set this for team projects so all clones use the same sync branch.
 # This setting persists across clones (unlike database config which is gitignored).
 # Can also use BEADS_SYNC_BRANCH env var for local override.
-# If not set, bd sync will require you to run 'bd config set sync.branch <branch>'.
+# If not set, bd sync will require you to run 'bd config set sync.branch=<branch>'.
 sync-branch: "beads-sync"
 
 # Multi-repo configuration (experimental - bd-307)

--- a/acfs/onboard/lessons/07_flywheel_loop.md
+++ b/acfs/onboard/lessons/07_flywheel_loop.md
@@ -187,7 +187,7 @@ bd init
 # can cause worktree conflicts. Once you have a `main` branch and a remote, run:
 git branch beads-sync main
 git push -u origin beads-sync
-bd config set sync.branch beads-sync
+bd config set sync.branch=beads-sync
 
 # 4. Spawn your agents
 ntm spawn my-first-project --cc=2 --cod=1 --gmi=1

--- a/apps/web/components/lessons/flywheel-loop-lesson.tsx
+++ b/apps/web/components/lessons/flywheel-loop-lesson.tsx
@@ -341,7 +341,7 @@ bd init
 # can cause worktree conflicts. Once you have a \`main\` branch and a remote, run:
 git branch beads-sync main
 git push -u origin beads-sync
-bd config set sync.branch beads-sync
+bd config set sync.branch=beads-sync
 
 # 4. Spawn your agents
 ntm spawn my-first-project --cc=2 --cod=1 --gmi=1


### PR DESCRIPTION
## Summary
- The `bd config set` command expects `key=value` format, not space-separated arguments
- Fixed all 3 occurrences in the documentation

## Files Changed
- `apps/web/components/lessons/flywheel-loop-lesson.tsx`
- `acfs/onboard/lessons/07_flywheel_loop.md`
- `.beads/config.yaml`

## Before
```bash
bd config set sync.branch beads-sync
# error: unexpected argument 'beads-sync' found
```

## After
```bash
bd config set sync.branch=beads-sync
# ✓ works correctly
```