### PR TITLE
fix(zshrc): pass unknown commands to acfs binary instead of showing help

### DIFF
--- a/acfs/zsh/acfs.zshrc
+++ b/acfs/zsh/acfs.zshrc
@@ -346,12 +346,13 @@ acfs() {
         echo "ACFS version unknown"
       fi
       ;;
-    help|-h|--help|*)
+    help|-h|--help)
       echo "ACFS - Agentic Coding Flywheel Setup"
       echo ""
       echo "Usage: acfs <command>"
       echo ""
       echo "Commands:"
+      echo "  newproj         Create new project with git, bd, claude settings"
       echo "  info            Quick system overview (hostname, IP, uptime, progress)"
       echo "  cheatsheet      Command reference (aliases, shortcuts)"
       echo "  dashboard, dash <generate|serve> - Static HTML dashboard"
@@ -367,6 +368,16 @@ acfs() {
       echo "  --json          JSON output for scripting"
       echo "  --html          Self-contained HTML dashboard (info only)"
       echo "  --minimal       Just the essentials (info only)"
+      ;;
+    *)
+      # Pass unknown commands to the binary (supports newproj and future commands)
+      if [[ -x "$acfs_bin" ]]; then
+        "$acfs_bin" "$cmd" "$@"
+      else
+        echo "Error: Unknown command '$cmd' and acfs binary not found at $acfs_bin"
+        echo "Try 'acfs help' for available commands, or re-run the ACFS installer."
+        return 1
+      fi
       ;;
   esac
 }


### PR DESCRIPTION
## Summary

The shell wrapper function `acfs()` in `acfs/zsh/acfs.zshrc` was treating all unrecognized commands as help requests instead of forwarding them to the binary at `~/.local/bin/acfs`.

This broke commands like `acfs newproj` which are:
- Documented in the README as the primary project creation interface
- Implemented in the binary
- But not explicitly handled in the wrapper's case statement

## Root Cause

The case statement ended with:
```zsh
help|-h|--help|*)
  # shows help
```

The `*` wildcard caught everything including valid commands like `newproj`.

## Changes

1. **Separate help from catch-all**: Changed `help|-h|--help|*)` to just `help|-h|--help)`
2. **Add smart passthrough**: New `*)` case that forwards unknown commands to the binary
3. **Update help text**: Added `newproj` to the displayed commands list
4. **Graceful error handling**: If binary is missing, shows helpful error message

## Before/After

**Before:**
```bash
$ acfs newproj myapp
# Shows help menu instead of creating project
```

**After:**
```bash
$ acfs newproj myapp
# Passes through to binary, creates project as expected
```

## Benefits

- `acfs newproj` now works as documented
- Forward compatibility: new binary commands work automatically without wrapper updates
- Maintains backward compatibility for all existing wrapper-handled commands
- Helpful error message if binary is missing

## Test Plan

- [x] `acfs newproj --help` shows binary's newproj help
- [x] `acfs --help` shows wrapper help with `newproj` listed
- [x] `acfs doctor` (existing command) still works
- [x] Unknown commands pass through to binary gracefully

---

🤖 Generated with [Claude Code](https://claude.ai/code)