### PR TITLE
fix: autofix preflight failures

### DIFF
--- a/scripts/lib/autofix_existing.sh
+++ b/scripts/lib/autofix_existing.sh
@@ -8,9 +8,9 @@
 _ACFS_AUTOFIX_EXISTING_SOURCED=1
 
 # Source the core autofix module
-SCRIPT_DIR="${SCRIPT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
+_AUTOFIX_EXISTING_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=autofix.sh
-source "${SCRIPT_DIR}/autofix.sh"
+source "${_AUTOFIX_EXISTING_DIR}/autofix.sh"
 
 # =============================================================================
 # Constants
@@ -162,6 +162,27 @@ autofix_existing_acfs_needs_handling() {
     markers=$(detect_existing_acfs 2>/dev/null) || true
 
     [[ -n "$markers" ]]
+}
+
+# Fix function for handle_autofix pattern
+# In --yes mode, defaults to upgrade; in interactive/dry-run, shows what would happen
+autofix_existing_fix() {
+    local mode="${1:-fix}"
+    
+    if [[ "$mode" == "dry-run" ]]; then
+        log_info "[DRY-RUN] Would handle existing ACFS installation"
+        log_info "  - Check installed version"
+        log_info "  - Offer upgrade or clean reinstall option"
+        return 0
+    fi
+    
+    # In fix mode: use upgrade strategy for non-interactive --yes mode
+    if handle_existing_installation "${ACFS_VERSION:-unknown}" "upgrade"; then
+        return 0
+    else
+        log_error "Failed to handle existing installation"
+        return 1
+    fi
 }
 
 # =============================================================================

--- a/scripts/lib/autofix_unattended.sh
+++ b/scripts/lib/autofix_unattended.sh
@@ -8,9 +8,9 @@
 _ACFS_AUTOFIX_UNATTENDED_SOURCED=1
 
 # Source the core autofix module
-SCRIPT_DIR="${SCRIPT_DIR:-$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)}"
+_AUTOFIX_UNATTENDED_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=autofix.sh
-source "${SCRIPT_DIR}/autofix.sh"
+source "${_AUTOFIX_UNATTENDED_DIR}/autofix.sh"
 
 # =============================================================================
 # Constants

--- a/scripts/lib/autofix_version_managers.sh
+++ b/scripts/lib/autofix_version_managers.sh
@@ -17,9 +17,9 @@ fi
 _ACFS_AUTOFIX_VERSION_MANAGERS_SH_LOADED=1
 
 # Source the autofix base library
-SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+_AUTOFIX_VERSION_MANAGERS_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck disable=SC1091
-source "$SCRIPT_DIR/autofix.sh"
+source "$_AUTOFIX_VERSION_MANAGERS_DIR/autofix.sh"
 
 # ============================================================
 # NVM Detection and Fix


### PR DESCRIPTION
Autofix preflight aborted in --yes/--dry-run because debug logging returned non-zero when ACFS_DEBUG was off, missing fix handlers triggered set -e exits, and autofix helpers resolved paths against the repo root, causing missing file errors and misleading log hints early in the run.

Fix debug logging to always succeed, initialize change-recording state before writes, preserve nounset around associative array updates, resolve helper paths relative to their own files, and add the missing existing-installation handler. These changes enable preflight to run non-interactively and prevent false failures under set -e.