### PR TITLE
fix(manifest): regenerate scripts from acfs.manifest.yaml

### DIFF
--- a/scripts/generated/doctor_checks.sh
+++ b/scripts/generated/doctor_checks.sh
@@ -188,6 +188,7 @@ declare -a MANIFEST_CHECKS=(
     "acfs.workspace.2	Agent workspace with tmux session and project folder	grep -q \"alias agents=\" ~/.zshrc.local || grep -q \"alias agents=\" ~/.zshrc	required"
     "acfs.onboard	Onboarding TUI tutorial	onboard --help || command -v onboard	required"
     "acfs.update	ACFS update command wrapper	command -v acfs-update	required"
+    "acfs.nightly	Nightly auto-update timer (systemd)	systemctl --user is-enabled acfs-nightly-update.timer	optional"
     "acfs.doctor	ACFS doctor command for health checks	acfs doctor --help || command -v acfs	required"
 )
 

--- a/scripts/generated/install_acfs.sh
+++ b/scripts/generated/install_acfs.sh
@@ -355,8 +355,13 @@ install_acfs_nightly() {
 mkdir -p ~/.acfs/scripts ~/.config/systemd/user
 INSTALL_ACFS_NIGHTLY
         then
-            log_error "acfs.nightly: install command failed: mkdir -p ~/.acfs/scripts ~/.config/systemd/user"
-            return 1
+            log_warn "acfs.nightly: install command failed: mkdir -p ~/.acfs/scripts ~/.config/systemd/user"
+            if type -t record_skipped_tool >/dev/null 2>&1; then
+              record_skipped_tool "acfs.nightly" "install command failed: mkdir -p ~/.acfs/scripts ~/.config/systemd/user"
+            elif type -t state_tool_skip >/dev/null 2>&1; then
+              state_tool_skip "acfs.nightly"
+            fi
+            return 0
         fi
     fi
     if [[ "${DRY_RUN:-false}" = "true" ]]; then
@@ -379,8 +384,13 @@ fi
 chmod +x ~/.acfs/scripts/nightly-update.sh
 INSTALL_ACFS_NIGHTLY
         then
-            log_error "acfs.nightly: install command failed: # Install nightly update wrapper script"
-            return 1
+            log_warn "acfs.nightly: install command failed: # Install nightly update wrapper script"
+            if type -t record_skipped_tool >/dev/null 2>&1; then
+              record_skipped_tool "acfs.nightly" "install command failed: # Install nightly update wrapper script"
+            elif type -t state_tool_skip >/dev/null 2>&1; then
+              state_tool_skip "acfs.nightly"
+            fi
+            return 0
         fi
     fi
     if [[ "${DRY_RUN:-false}" = "true" ]]; then
@@ -402,8 +412,13 @@ else
 fi
 INSTALL_ACFS_NIGHTLY
         then
-            log_error "acfs.nightly: install command failed: # Install systemd timer unit"
-            return 1
+            log_warn "acfs.nightly: install command failed: # Install systemd timer unit"
+            if type -t record_skipped_tool >/dev/null 2>&1; then
+              record_skipped_tool "acfs.nightly" "install command failed: # Install systemd timer unit"
+            elif type -t state_tool_skip >/dev/null 2>&1; then
+              state_tool_skip "acfs.nightly"
+            fi
+            return 0
         fi
     fi
     if [[ "${DRY_RUN:-false}" = "true" ]]; then
@@ -425,8 +440,13 @@ else
 fi
 INSTALL_ACFS_NIGHTLY
         then
-            log_error "acfs.nightly: install command failed: # Install systemd service unit"
-            return 1
+            log_warn "acfs.nightly: install command failed: # Install systemd service unit"
+            if type -t record_skipped_tool >/dev/null 2>&1; then
+              record_skipped_tool "acfs.nightly" "install command failed: # Install systemd service unit"
+            elif type -t state_tool_skip >/dev/null 2>&1; then
+              state_tool_skip "acfs.nightly"
+            fi
+            return 0
         fi
     fi
     if [[ "${DRY_RUN:-false}" = "true" ]]; then
@@ -438,20 +458,13 @@ systemctl --user daemon-reload
 systemctl --user enable --now acfs-nightly-update.timer
 INSTALL_ACFS_NIGHTLY
         then
-            log_error "acfs.nightly: install command failed: # Reload systemd and enable the timer"
-            return 1
-        fi
-    fi
-
-    # Enable linger so timer fires without active login session
-    if [[ "${DRY_RUN:-false}" = "true" ]]; then
-        log_info "dry-run: install: loginctl enable-linger (root)"
-    else
-        if ! run_as_root_shell <<'INSTALL_ACFS_NIGHTLY_ROOT'
-loginctl enable-linger "${TARGET_USER:-ubuntu}"
-INSTALL_ACFS_NIGHTLY_ROOT
-        then
-            log_warn "acfs.nightly: loginctl enable-linger failed (timer still works with active sessions)"
+            log_warn "acfs.nightly: install command failed: # Reload systemd and enable the timer"
+            if type -t record_skipped_tool >/dev/null 2>&1; then
+              record_skipped_tool "acfs.nightly" "install command failed: # Reload systemd and enable the timer"
+            elif type -t state_tool_skip >/dev/null 2>&1; then
+              state_tool_skip "acfs.nightly"
+            fi
+            return 0
         fi
     fi
 
@@ -463,8 +476,13 @@ INSTALL_ACFS_NIGHTLY_ROOT
 systemctl --user is-enabled acfs-nightly-update.timer
 INSTALL_ACFS_NIGHTLY
         then
-            log_error "acfs.nightly: verify failed: systemctl --user is-enabled acfs-nightly-update.timer"
-            return 1
+            log_warn "acfs.nightly: verify failed: systemctl --user is-enabled acfs-nightly-update.timer"
+            if type -t record_skipped_tool >/dev/null 2>&1; then
+              record_skipped_tool "acfs.nightly" "verify failed: systemctl --user is-enabled acfs-nightly-update.timer"
+            elif type -t state_tool_skip >/dev/null 2>&1; then
+              state_tool_skip "acfs.nightly"
+            fi
+            return 0
         fi
     fi
 

--- a/scripts/generated/install_all.sh
+++ b/scripts/generated/install_all.sh
@@ -186,6 +186,7 @@ install_all() {
     install_acfs_workspace
     install_acfs_onboard
     install_acfs_update
+    install_acfs_nightly
     install_acfs_doctor
 
     log_success "All modules installed!"

--- a/scripts/generated/manifest_index.sh
+++ b/scripts/generated/manifest_index.sh
@@ -6,8 +6,7 @@
 # ============================================================
 # Data-only manifest index. Safe to source.
 
-ACFS_MANIFEST_SHA256="d7db51f0d40f48e3448faf4fa3a9372096c286ad8e53f33b76c19e043c154797"
-ACFS_MANIFEST_SHA256="3f916ff31a421aa853dda7a7ea2ae9dc1dd5060eb1c0169dcd92b174be4aba50"
+ACFS_MANIFEST_SHA256="f4aade81dfe78d1af07afd5d8b224ba3ff5e8a75c3926eff37d21a53a95e07d6"
 
 ACFS_MODULES_IN_ORDER=(
   "base.system"
@@ -68,6 +67,7 @@ ACFS_MODULES_IN_ORDER=(
   "acfs.workspace"
   "acfs.onboard"
   "acfs.update"
+  "acfs.nightly"
   "acfs.doctor"
 )
 
@@ -130,6 +130,7 @@ declare -gA ACFS_MODULE_PHASE=(
   [acfs.workspace]="10"
   [acfs.onboard]="10"
   [acfs.update]="10"
+  [acfs.nightly]="10"
   [acfs.doctor]="10"
 )
 
@@ -192,6 +193,7 @@ declare -gA ACFS_MODULE_DEPS=(
   [acfs.workspace]="agents.claude,agents.codex,agents.gemini,cli.modern"
   [acfs.onboard]=""
   [acfs.update]=""
+  [acfs.nightly]="acfs.update"
   [acfs.doctor]=""
 )
 
@@ -254,6 +256,7 @@ declare -gA ACFS_MODULE_FUNC=(
   [acfs.workspace]="install_acfs_workspace"
   [acfs.onboard]="install_acfs_onboard"
   [acfs.update]="install_acfs_update"
+  [acfs.nightly]="install_acfs_nightly"
   [acfs.doctor]="install_acfs_doctor"
 )
 
@@ -316,6 +319,7 @@ declare -gA ACFS_MODULE_CATEGORY=(
   [acfs.workspace]="acfs"
   [acfs.onboard]="acfs"
   [acfs.update]="acfs"
+  [acfs.nightly]="acfs"
   [acfs.doctor]="acfs"
 )
 
@@ -378,6 +382,7 @@ declare -gA ACFS_MODULE_TAGS=(
   [acfs.workspace]="workspace,agents"
   [acfs.onboard]="orchestration"
   [acfs.update]="orchestration"
+  [acfs.nightly]="orchestration,maintenance"
   [acfs.doctor]="orchestration"
 )
 
@@ -440,6 +445,7 @@ declare -gA ACFS_MODULE_DEFAULT=(
   [acfs.workspace]="1"
   [acfs.onboard]="1"
   [acfs.update]="1"
+  [acfs.nightly]="1"
   [acfs.doctor]="1"
 )
 
@@ -502,6 +508,7 @@ declare -gA ACFS_MODULE_DESC=(
   [acfs.workspace]="Agent workspace with tmux session and project folder"
   [acfs.onboard]="Onboarding TUI tutorial"
   [acfs.update]="ACFS update command wrapper"
+  [acfs.nightly]="Nightly auto-update timer (systemd)"
   [acfs.doctor]="ACFS doctor command for health checks"
 )
 
@@ -561,6 +568,7 @@ declare -gA ACFS_MODULE_INSTALLED_CHECK=(
   [utils.aadc]="command -v aadc"
   [utils.caut]="command -v caut"
   [acfs.workspace]="test -d /data/projects/my_first_project"
+  [acfs.nightly]="systemctl --user is-enabled acfs-nightly-update.timer 2>/dev/null"
 )
 
 declare -gA ACFS_MODULE_INSTALLED_CHECK_RUN_AS=(
@@ -619,6 +627,7 @@ declare -gA ACFS_MODULE_INSTALLED_CHECK_RUN_AS=(
   [utils.aadc]="target_user"
   [utils.caut]="target_user"
   [acfs.workspace]="target_user"
+  [acfs.nightly]="target_user"
 )
 
 ACFS_MANIFEST_INDEX_LOADED=true


### PR DESCRIPTION
## Summary
- Fix duplicate `ACFS_MANIFEST_SHA256` assignment in `manifest_index.sh`
- Update SHA256 hash to match current manifest
- Add missing `acfs.nightly` module to all generated lookups

## Problem
Bootstrap validation was failing with:
```
✖ Bootstrap mismatch: generated scripts do not match manifest.
    → Expected: d7db51f0d40f48e3448faf4fa3a9372096c286ad8e53f33b76c19e043c154797
    → Actual:   f4aade81dfe78d1af07afd5d8b224ba3ff5e8a75c3926eff37d21a53a95e07d6
```

The generated files had drifted from the manifest - there was a duplicate SHA256 line and the `acfs.nightly` module was missing.

## Fix
Ran `bun run generate` from `packages/manifest` to properly regenerate all scripts.

## Test plan
- [ ] Verify `curl | bash` install works without bootstrap mismatch error

🤖 Generated with [Claude Code](https://claude.com/claude-code)