### PR TITLE
Fix `temp_file: unbound variable` in `autofix.sh`

### DIFF
--- a/scripts/lib/autofix.sh
+++ b/scripts/lib/autofix.sh
@@ -117,7 +117,7 @@ write_atomic() {
         log_error "Failed to create temp file for atomic write: $target_file"
         return 1
     }
-    trap 'rm -f "$temp_file" 2>/dev/null || true' RETURN
+    trap 'rm -f "$temp_file" 2>/dev/null || true; trap - RETURN' RETURN
 
     # Write content to temp file
     if ! printf '%s\n' "$content" > "$temp_file"; then
@@ -156,7 +156,7 @@ append_atomic() {
         log_error "Failed to create temp file for atomic append: $target_file"
         return 1
     }
-    trap 'rm -f "$temp_file" 2>/dev/null || true' RETURN
+    trap 'rm -f "$temp_file" 2>/dev/null || true; trap - RETURN' RETURN
 
     # Copy existing content + new line to temp
     if [[ -f "$target_file" ]]; then
@@ -296,7 +296,7 @@ repair_state_files() {
             log_error "Failed to create temp file for changes repair"
             return 1
         }
-        trap 'rm -f "$temp_file" 2>/dev/null || true' RETURN
+        trap 'rm -f "$temp_file" 2>/dev/null || true; trap - RETURN' RETURN
         while IFS= read -r line; do
             [[ -z "$line" ]] && continue
             if echo "$line" | jq -e . >/dev/null 2>&1; then
@@ -333,7 +333,7 @@ repair_state_files() {
             log_error "Failed to create temp file for undos repair"
             return 1
         }
-        trap 'rm -f "$temp_file" 2>/dev/null || true' RETURN
+        trap 'rm -f "$temp_file" 2>/dev/null || true; trap - RETURN' RETURN
         while IFS= read -r line; do
             [[ -z "$line" ]] && continue
             if echo "$line" | jq -e . >/dev/null 2>&1; then


### PR DESCRIPTION
Hi,
thanks for this very interesting project!

I'm getting following error: `/home/ubuntu/Development/repos/agentic_coding_flywheel_setup/scripts/lib/autofix.sh: line 398: temp_file: unbound variable`
when running this `./install.sh --yes --force-reinstall --mode vibe --only stack.ultimate_bug_scanner`

This is on latest `main` branch running on VPS.

I'm not Bash guru, I do mostly TypeScript. This fix was generated using Claude Code Opus 4.6.
The patterns seems to be used in other bash scripts too.