### PR TITLE
feat(newproj): honor ACFS_PROJECTS_DIR in non-interactive CLI

### DIFF
--- a/scripts/lib/newproj.sh
+++ b/scripts/lib/newproj.sh
@@ -613,7 +613,10 @@ main() {
             echo -e "${YELLOW}Test mode detected: redirecting to $project_dir${NC}" >&2
         fi
     elif [[ -z "$project_dir" ]]; then
-        project_dir="/data/projects/$project_name"
+        # Honor ACFS_PROJECTS_DIR for parity with the interactive wizard
+        # (newproj_screens/screen_directory.sh::get_default_projects_dir);
+        # fall back to the canonical /data/projects default.
+        project_dir="${ACFS_PROJECTS_DIR:-/data/projects}/$project_name"
     fi
 
     if declare -f normalize_path &>/dev/null; then


### PR DESCRIPTION
## Motivation

`ACFS_PROJECTS_DIR` is the documented way to override the default projects directory, and the **interactive wizard** already honors it:

```sh
# scripts/lib/newproj_screens/screen_directory.sh
get_default_projects_dir() {
    # Priority: env var > /data/projects > ~/projects > ~/Projects > $HOME
    if [[ -n "${ACFS_PROJECTS_DIR:-}" ]] && [[ -d "$ACFS_PROJECTS_DIR" ]]; then
        echo "$ACFS_PROJECTS_DIR"
    ...
}
```

But the **non-interactive CLI** (`acfs newproj <name>` with no explicit directory) ignored it and hardcoded `/data/projects`:

```sh
# scripts/lib/newproj.sh
elif [[ -z "$project_dir" ]]; then
    project_dir="/data/projects/$project_name"
fi
```

So `ACFS_PROJECTS_DIR=$HOME/code acfs newproj foo` sent the wizard to `~/code` but the CLI to `/data/projects/foo` — an inconsistency that surprises anyone who keeps projects outside `/data/projects`.

## Change

Make the CLI default honor `ACFS_PROJECTS_DIR`, falling back to the canonical `/data/projects`:

```sh
project_dir="${ACFS_PROJECTS_DIR:-/data/projects}/$project_name"
```

One line, scoped to the no-explicit-directory branch. An explicitly passed directory argument and the test-mode `/tmp` safeguard are unchanged.

## Testing

- `shellcheck -x scripts/lib/newproj.sh` — clean.
- Verified resolution: with `ACFS_PROJECTS_DIR=$HOME/github`, the branch resolves to `$HOME/github/<name>`; unset, it resolves to `/data/projects/<name>`.
- No bats test added: the patched branch is unreachable under `ACFS_TEST_MODE`/`BATS_TEST_NAME` (the test-mode safeguard at the top of this block redirects to `/tmp` first), so a through-`main()` test can't exercise it without refactoring the resolution into a standalone function. The env-var semantics mirror the already-exercised wizard path.

## Review focus

- Fallback precedence: CLI uses `${ACFS_PROJECTS_DIR:-/data/projects}` (simple env-var-or-default). The wizard has a richer chain (`> ~/projects > ~/Projects`) and an existence check. If you'd prefer the CLI to share `get_default_projects_dir` exactly, I can refactor instead.