### PR TITLE
fix(newproj): drop hardcoded dated model snapshot from settings template

### DIFF
--- a/scripts/lib/newproj.sh
+++ b/scripts/lib/newproj.sh
@@ -799,7 +799,6 @@ EOF
             echo -e "${GREEN}Creating Claude settings...${NC}"
             cat > .claude/settings.local.json << 'EOF'
 {
-  "model": "claude-sonnet-4-6-20250514",
   "permissions": {
     "allow_file_read": true,
     "allow_file_write": true,

--- a/scripts/lib/newproj_screens/screen_progress.sh
+++ b/scripts/lib/newproj_screens/screen_progress.sh
@@ -342,7 +342,6 @@ venv/
             fi
 
             local claude_settings='{
-  "model": "claude-sonnet-4-6-20250514",
   "permissions": {
     "allow_file_read": true,
     "allow_file_write": true,


### PR DESCRIPTION
## Bug

The `.claude/settings.local.json` template generated by `acfs newproj` hardcodes a dated Claude model snapshot:

```json
{
  "model": "claude-sonnet-4-6-20250514",
  ...
}
```

Dated Claude model snapshots are deprecated roughly 12 months after release. As of today every project created via `acfs newproj` is dead-on-arrival: Claude Code refuses to start with

> There's an issue with the selected model (claude-sonnet-4-6-20250514). It may not exist or you may not have access to it. Run /model to pick a different model.

Operators currently have to `jq 'del(.model)' .claude/settings.local.json` (or hand-edit) on every fresh project before Claude Code will run.

## Fix

Remove the `model` field from the template in both places it appears:

- `scripts/lib/newproj.sh` (CLI heredoc path)
- `scripts/lib/newproj_screens/screen_progress.sh` (TUI/interactive path)

With no `model` field, Claude Code falls back to the account's default model, which auto-tracks the user's plan tier (Pro/Max/Team) and stays correct over time without further maintenance. This matches what `acfs newproj` users almost certainly want and avoids the recurring deprecation treadmill.

The alternative (pin to the unversioned alias `claude-sonnet-4-6`) was considered, but ACFS doesn't appear to mandate Sonnet as the recommended model for new projects (e.g. `install.sh` already references `claude-opus-4-7` elsewhere), so deferring to the account default is the safer default.

## Scope

Two-line change, no new config knobs, no test changes required (no existing test asserts the model string). Other dated model identifiers elsewhere in the repo (e.g. a `bodyPreview` string inside `apps/web/components/lessons/rust-proxy-lesson.tsx`) are intentionally left untouched — those are demo content, not user-facing config.

## Verified locally

1. `bash -n scripts/lib/newproj_screens/screen_progress.sh` — passes.
2. Emitted JSON is valid and parses cleanly with `python3 -m json.tool`.
3. No `bats` tests reference `"model"` or the snapshot string, so no test updates are required.