### PR TITLE
fix(supabase): correct CLI checksums asset name (upstream renamed to checksums.txt)

### DIFF
--- a/acfs.manifest.yaml
+++ b/acfs.manifest.yaml
@@ -1143,7 +1143,7 @@ modules:
         version="${tag#v}"
         base_url="https://github.com/supabase/cli/releases/download/${tag}"
         tarball="supabase_linux_${arch}.tar.gz"
-        checksums="supabase_${version}_checksums.txt"
+        checksums="checksums.txt"
 
         tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/acfs-supabase.XXXXXX")"
         tmp_tgz="$(mktemp "${TMPDIR:-/tmp}/acfs-supabase.tgz.XXXXXX")"

--- a/apps/web/lib/generated/manifest-modules.ts
+++ b/apps/web/lib/generated/manifest-modules.ts
@@ -32,7 +32,7 @@ export interface ManifestProvenanceMetadata {
 
 export const manifestProvenance = {
   acfsVersion: "0.7.0",
-  manifestSha256: "72fd1123034f4cc4dfd71d9a362e9cbf423f8aa6c37460a60352816cb7557b91",
+  manifestSha256: "c67cd21b32ce544009fad69c1b7ed3af3942af77f649697f8eed2ab0f10c915b",
   checksumsYamlSha256: "05273ad1441fcc494cfa71b9da5b45e272c4b764b9cb99bba8e8c12350cf73f5",
 } as const satisfies ManifestProvenanceMetadata;
 

--- a/install.sh
+++ b/install.sh
@@ -5925,7 +5925,7 @@ install_supabase_cli_release() {
     local version="${tag#v}"
     local base_url="https://github.com/supabase/cli/releases/download/${tag}"
     local tarball="supabase_linux_${arch}.tar.gz"
-    local checksums="supabase_${version}_checksums.txt"
+    local checksums="checksums.txt"
 
     local tmp_dir=""
     local tmp_tgz=""

--- a/scripts/generated/install_cloud.sh
+++ b/scripts/generated/install_cloud.sh
@@ -717,7 +717,7 @@ fi
 version="${tag#v}"
 base_url="https://github.com/supabase/cli/releases/download/${tag}"
 tarball="supabase_linux_${arch}.tar.gz"
-checksums="supabase_${version}_checksums.txt"
+checksums="checksums.txt"
 
 tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/acfs-supabase.XXXXXX")"
 tmp_tgz="$(mktemp "${TMPDIR:-/tmp}/acfs-supabase.tgz.XXXXXX")"

--- a/scripts/generated/internal_checksums.sh
+++ b/scripts/generated/internal_checksums.sh
@@ -10,7 +10,7 @@
 declare -gA ACFS_INTERNAL_CHECKSUMS=(
   [scripts/lib/security.sh]="d8b1f1766814ae83a2ac89dd919d4d5ece7d4be9a559c066f4508dab59243903"
   [scripts/lib/agents.sh]="66fac24c48c9ce7d17ae213ff2f8669a1902e77f01266f4eeaccdcef09e02856"
-  [scripts/lib/update.sh]="7bcad29c1bf19308841c4f090361b405b3a7ae1ddc2b0783705686f45b9cfb86"
+  [scripts/lib/update.sh]="91a2a36bc7b978060d4bab5f053f86f489ed48b4026414d7b548d27160bbbd8b"
   [scripts/lib/doctor.sh]="f784629ae65d0a258d92d759b9dc785d66a68b6b439930c78bef79f038c476ea"
   [scripts/lib/doctor_fix.sh]="074e8512b1b5cc6a6d27513d5463b585b0e5c35540180e58747793a7c67d3a6f"
   [scripts/lib/offline_artifact_pack.sh]="38c6c2821044e2ac197b686403902419d73859f5eb370244f27e2ae54a5f1db1"

--- a/scripts/generated/manifest_index.sh
+++ b/scripts/generated/manifest_index.sh
@@ -6,7 +6,7 @@
 # ============================================================
 # Data-only manifest index. Safe to source.
 
-ACFS_MANIFEST_SHA256="72fd1123034f4cc4dfd71d9a362e9cbf423f8aa6c37460a60352816cb7557b91"
+ACFS_MANIFEST_SHA256="c67cd21b32ce544009fad69c1b7ed3af3942af77f649697f8eed2ab0f10c915b"
 
 ACFS_MODULES_IN_ORDER=(
   "base.system"

--- a/scripts/lib/update.sh
+++ b/scripts/lib/update.sh
@@ -5010,7 +5010,7 @@ fi
 version="${tag#v}"
 base_url="https://github.com/supabase/cli/releases/download/${tag}"
 tarball="supabase_linux_${arch}.tar.gz"
-checksums="supabase_${version}_checksums.txt"
+checksums="checksums.txt"
 
 tmp_dir="$(mktemp -d "${TMPDIR:-/tmp}/acfs-supabase.XXXXXX" 2>/dev/null)" || tmp_dir=""
 tmp_tgz="$(mktemp "${TMPDIR:-/tmp}/acfs-supabase.tgz.XXXXXX" 2>/dev/null)" || tmp_tgz=""


### PR DESCRIPTION
## Problem

`acfs-update` (and fresh installs) fail the **Supabase CLI** step on every run with:

```
Supabase CLI: failed to download checksums
```

leaving the Supabase CLI stuck at an old version.

## Root cause

Supabase renamed its release **checksums asset**. The installer builds the URL as:

```bash
checksums="supabase_${version}_checksums.txt"
```

but current releases ship the file as **`checksums.txt`** (unversioned). The versioned name 404s, so the checksums download fails. (The tarball download still succeeds because it uses the unversioned `supabase_linux_<arch>.tar.gz` alias — only the checksums URL is stale.)

Verified against the latest release `v2.105.0`: its assets include `checksums.txt`, not `supabase_2.105.0_checksums.txt`.

## Fix

Use the current asset name:

```bash
checksums="checksums.txt"
```

Applied to the manifest source (`acfs.manifest.yaml`) and regenerated artifacts (`bun run generate`), plus the hand-maintained copies in `scripts/lib/update.sh` and `install.sh`. The generate drift check is clean, and `checksums.yaml` is unaffected (Supabase uses a custom inline installer, not a `verified_installer`).

## Verification

A manual, checksum-verified install of `v2.105.0` using the corrected asset name succeeds — the downloaded `supabase_2.105.0_linux_amd64.tar.gz` sha256 matches its entry in `checksums.txt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
