### PR TITLE
TEST (do not merge): prove internal-checksum-guard fires on hashed-script drift

### DIFF
--- a/scripts/lib/logging.sh
+++ b/scripts/lib/logging.sh
@@ -443,3 +443,4 @@ if ! declare -f timer_end >/dev/null; then
         log_detail "Completed in ${duration}s"
     }
 fi
+# guard-livefire-ci-proof 1786995731


### PR DESCRIPTION
Deliberate drift: scripts/lib/logging.sh edited without regenerating scripts/generated/internal_checksums.sh. Watching internal-checksum-guard.yml go red. Will be closed without merging.